### PR TITLE
Fix fatal error occuring on some admin pages

### DIFF
--- a/scheduled-post-guardian.php
+++ b/scheduled-post-guardian.php
@@ -86,7 +86,8 @@ class Scheduled_Post_Guardian_Plugin {
 	}
 
 	public function run_on_edit_dot_php( $run ) {
-		if ( ! $run && is_admin() && 'edit' === get_current_screen()->base ) {
+		if ( ! $run && is_admin() && function_exists('get_current_screen') &&
+			get_current_screen() !== null && 'edit' === get_current_screen()->base ) {
 			return true;
 		}
 		return $run;


### PR DESCRIPTION
I noticed in my error logs that the plugin throws a couple of errors on some admin pages.

Once it generated an error because the function didn't exist. 
Most of the time it was throwing an error because `get_current_screen()` was returning `null`.
So I've added two conditions to prevent these errors.